### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,55 +5,50 @@ Maintainers
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
-| Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
-| Brett Logan | [btl5037][btl5037] | btl5037 | <brett.t.logan@ibm.com>
-| Artem Barger | [c0rwin][c0rwin] | c0rwin | <bartem@il.ibm.com>
-| Danny Cao | [caod123][caod123] | caod | <dcao@us.ibm.com>
-| Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
-| Chris Ferris | [christo4ferris][christo4ferris] | cbf | <chris.ferris@gmail.com>
-| Dave Enyeart | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
-| Jay Guo | [guoger][guoger] | guoger | <guojiannan1101@gmail.com>
-| Jason Yellick | [jyellick][jyellick] | jyellick | <jyellick@us.ibm.com>
-| Manish Sethi | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
-| Gari Singh | [mastersingh24][mastersingh24] | mastersingh24 | <gari.r.singh@gmail.com>
-| Matthew Sykes | [sykesm][sykesm] | sykesm | <sykesmat@us.ibm.com>
-| Yacov Manevich | [yacovm][yacovm] | yacovm | <yacovm@il.ibm.com>
 
 **Documentation Maintainers**
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
-| Chris Gabriel  | [denali49][denali49] | cmgabriel | <alaskadd@gmail.com>
-| Joe Alewine | [joealewine][joealewine] | joe-alewine | <joe.alewine@ibm.com>
-| Nikhil Gupta | [nikhil550][nikhil550] | nikhilgupta | <negupta@us.ibm.com>
-| Anthony O'Dowd | [odowdaibm][odowdaibm] | odowdaibm | <a_o-dowd@uk.ibm.com>
-| Pam Andrejko | [pamandrejko][pamandrejko] | pandrejko | <pama@ibm.com>
 
 **Release Managers**
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
-| Brett Logan | [btl5037][btl5037] | btl5037 | <brett.t.logan@ibm.com>
-| Chris Ferris | [christo4ferris][christo4ferris] | cbf | <chris.ferris@gmail.com>
-| Dave Enyeart | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
-| Gari Singh | [mastersingh24][mastersingh24] | mastersingh24 | <gari.r.singh@gmail.com>
 
 **Retired Maintainers**
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
+| Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
+| Anthony O'Dowd | [odowdaibm][odowdaibm] | odowdaibm | <a_o-dowd@uk.ibm.com>
+| Artem Barger | [c0rwin][c0rwin] | c0rwin | <bartem@il.ibm.com>
 | Binh Nguyen | [binhn][binhn] | binhn | <binh1010010110@gmail.com>
+| Brett Logan | [btl5037][btl5037] | btl5037 | <brett.t.logan@ibm.com>
+| Chris Ferris | [christo4ferris][christo4ferris] | cbf | <chris.ferris@gmail.com>
+| Chris Gabriel  | [denali49][denali49] | cmgabriel | <alaskadd@gmail.com>
+| Danny Cao | [caod123][caod123] | caod | <dcao@us.ibm.com>
+| Dave Enyeart | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
 | Gabor Hosszu | [gabre][gabre] | hgabor | <gabor@digitalasset.com>
+| Gari Singh | [mastersingh24][mastersingh24] | mastersingh24 | <gari.r.singh@gmail.com>
 | Greg Haskins | [ghaskins][ghaskins] | ghaskins | <gregory.haskins@gmail.com>
-| Jonathan Levi | [hacera][hacera] |JonathanLevi | <jonathan@hacera.com>
-| Yaoguo Jiang | [jiangyaoguo][jiangyaoguo] | jiangyaoguo | <jiangyaoguo@gmail.com>
+| Jason Yellick | [jyellick][jyellick] | jyellick | <jyellick@us.ibm.com>
+| Jay Guo | [guoger][guoger] | guoger | <guojiannan1101@gmail.com>
 | Jim Zhang | [jimthematrix][jimthematrix] | jimthematrix | <jim_the_matrix@hotmail.com>
-| Kostas Christidis | [kchristidis][kchristidis] | kostas | <kostas@gmail.com>
-| Srinivasan Muralidharan | [muralisrini][muralisrini] | muralisr | <srinivasan.muralidharan99@gmail.com>
+| Joe Alewine | [joealewine][joealewine] | joe-alewine | <joe.alewine@ibm.com>
+| Jonathan Levi | [hacera][hacera] |JonathanLevi | <jonathan@hacera.com>
 | Keith Smith | [smithbk][smithbk] | smithbk | <bksmith@us.ibm.com>
+| Kostas Christidis | [kchristidis][kchristidis] | kostas | <kostas@gmail.com>
+| Manish Sethi | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
+| Matthew Sykes | [sykesm][sykesm] | sykesm | <sykesmat@us.ibm.com>
+| Nikhil Gupta | [nikhil550][nikhil550] | nikhilgupta | <negupta@us.ibm.com>
+| Pam Andrejko | [pamandrejko][pamandrejko] | pandrejko | <pama@ibm.com>
+| Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
 | Sheehan Anderson | [srderson][srderson] | sheehan | <sranderson@gmail.com>
+| Srinivasan Muralidharan | [muralisrini][muralisrini] | muralisr | <srinivasan.muralidharan99@gmail.com>
 | Tamas Blummer | [tamasblummer][tamasblummer] | tamas | <tamas@digitalasset.com>
-
+| Yacov Manevich | [yacovm][yacovm] | yacovm | <yacovm@il.ibm.com>
+| Yaoguo Jiang | [jiangyaoguo][jiangyaoguo] | jiangyaoguo | <jiangyaoguo@gmail.com>
 [ale-linux]: https://github.com/ale-linux
 [binhn]: https://github.com/binhn
 [btl5037]: https://github.com/btl5037


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
